### PR TITLE
Ingredients should have keywords to will be ignored

### DIFF
--- a/Api/Models/IngredientViewModel.cs
+++ b/Api/Models/IngredientViewModel.cs
@@ -20,13 +20,15 @@ namespace Api.Models
     public class IngredientUpdateViewModel
     {
         public IngredientUpdateRequest Request { get; set; }
-        public List<string> Keywords { get; set; }
         public List<string> AllergyKeywords { get; set; }
+        public List<string> IgnoreKeywords { get; set; }
+        public List<string> Keywords { get; set; }
 
         public IngredientUpdateViewModel()
         {
-            Keywords = new List<string>();
             AllergyKeywords = new List<string>();
+            IgnoreKeywords = new List<string>();
+            Keywords = new List<string>();
         }
 
         public static IngredientUpdateViewModel Map(Ingredient ingredient, IMapper mapper)
@@ -36,8 +38,9 @@ namespace Api.Models
                 Request = mapper.Map<IngredientUpdateRequest>(ingredient)
             };
 
-            ingredientUpdateViewModel.Keywords.AddRange(ingredient.Keywords);
             ingredientUpdateViewModel.AllergyKeywords.AddRange(ingredient.AllergyKeywords);
+            ingredientUpdateViewModel.IgnoreKeywords.AddRange(ingredient.IgnoreKeywords);
+            ingredientUpdateViewModel.Keywords.AddRange(ingredient.Keywords);
 
             return ingredientUpdateViewModel;
         }

--- a/Api/Models/IngredientViewModel.cs
+++ b/Api/Models/IngredientViewModel.cs
@@ -36,7 +36,7 @@ namespace Api.Models
                 Request = mapper.Map<IngredientUpdateRequest>(ingredient)
             };
 
-            ingredientUpdateViewModel.Keywords.AddRange(ingredient.KeyWords);
+            ingredientUpdateViewModel.Keywords.AddRange(ingredient.Keywords);
             ingredientUpdateViewModel.AllergyKeywords.AddRange(ingredient.AllergyKeywords);
 
             return ingredientUpdateViewModel;

--- a/Api/Startup.cs
+++ b/Api/Startup.cs
@@ -9,6 +9,7 @@ using System;
 using AutoMapper;
 using DataTables.AspNet.AspNetCore;
 using Api.Controllers;
+using Api.Models;
 
 namespace Api
 {
@@ -27,7 +28,7 @@ namespace Api
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
-            services.AddAutoMapper();
+            services.AddAutoMapper(typeof(ApiMapperConfiguration), typeof(ApplicationMapperConfiguration));
             services.RegisterDataTables();
 
             IConfigurationRoot configuration = new ConfigurationBuilder()

--- a/Api/Views/Ingredient/Ingredient.js
+++ b/Api/Views/Ingredient/Ingredient.js
@@ -20,26 +20,11 @@
     });
 }
 
-export function initUpdate(keywords, allergyKeywords) {
+export function initUpdate(allergyKeywords, ignoreKeywords, keywords) {
     Utils.initSelect();
 
-    var keywordsChipsElement = document.querySelector('#keywords-chips');
-    var options = {
-        data: keywords,
-        placeholder: 'Ingrediënten',
-        secondaryPlaceholder: 'ingrediënt',
-        onChipAdd: function() {
-            UpdateKeywordsString('Request_KeywordsString', this);
-        },
-        onChipDelete: function() {
-            UpdateKeywordsString('Request_KeywordsString', this);
-        }
-    }
-
-    M.Chips.init(keywordsChipsElement, options);
-
-    var allergykeywordsChipsElement = document.querySelector('#allergykeywords-chips');
-    var optionsAllergy = {
+    var allergyKeywordsChipsElement = document.querySelector('#allergyKeywords-chips');
+    var optionsAllergyKeywords = {
         data: allergyKeywords,
         placeholder: 'Allergiën',
         secondaryPlaceholder: 'allergie',
@@ -51,7 +36,37 @@ export function initUpdate(keywords, allergyKeywords) {
         }
     }
 
-    M.Chips.init(allergykeywordsChipsElement, optionsAllergy);
+    M.Chips.init(allergyKeywordsChipsElement, optionsAllergyKeywords);
+
+    var ignoreKeywordsChipsElement = document.querySelector('#ignoreKeywords-chips');
+    var optionsIgnoreKeywords = {
+        data: ignoreKeywords,
+        placeholder: 'Negeren',
+        secondaryPlaceholder: 'negeren',
+        onChipAdd: function() {
+            UpdateKeywordsString('Request_IgnoreKeywordsString', this);
+        },
+        onChipDelete: function() {
+            UpdateKeywordsString('Request_IgnoreKeywordsString', this);
+        }
+    }
+
+    M.Chips.init(ignoreKeywordsChipsElement, optionsIgnoreKeywords);
+
+    var keywordsChipsElement = document.querySelector('#keywords-chips');
+    var optionsKeywords = {
+        data: keywords,
+        placeholder: 'Ingrediënten',
+        secondaryPlaceholder: 'ingrediënt',
+        onChipAdd: function() {
+            UpdateKeywordsString('Request_KeywordsString', this);
+        },
+        onChipDelete: function() {
+            UpdateKeywordsString('Request_KeywordsString', this);
+        }
+    }
+
+    M.Chips.init(keywordsChipsElement, optionsKeywords);
 }
 
 function UpdateKeywordsString(id, chips) {

--- a/Api/Views/Ingredient/Update.cshtml
+++ b/Api/Views/Ingredient/Update.cshtml
@@ -8,19 +8,25 @@
 
 <script type="text/javascript">
     $(function() {
-        var keywords = [
-            @foreach(var keyword in Model.Keywords)
-            {
-                <text>{tag: '@keyword'},</text>
-            }
-        ];
         var allergyKeywords = [
             @foreach(var allergyKeyword in Model.AllergyKeywords)
             {
                 <text>{tag: '@allergyKeyword'},</text>
             }
         ];
-        Ingredient.initUpdate(keywords, allergyKeywords);
+        var ignoreKeywords = [
+            @foreach(var ignoreKeyword in Model.IgnoreKeywords)
+            {
+                <text>{tag: '@ignoreKeyword'},</text>
+            }
+        ];
+        var keywords = [
+            @foreach(var keyword in Model.Keywords)
+            {
+                <text>{tag: '@keyword'},</text>
+            }
+        ];
+        Ingredient.initUpdate(allergyKeywords, ignoreKeywords, keywords);
     });
 </script>
 
@@ -36,8 +42,9 @@
 {
 <div class="row">
     @Html.HiddenFor(_ => _.Request.Id)
-    @Html.HiddenFor(_ => _.Request.KeywordsString)
     @Html.HiddenFor(_ => _.Request.AllergyKeywordsString)
+    @Html.HiddenFor(_ => _.Request.IgnoreKeywordsString)
+    @Html.HiddenFor(_ => _.Request.KeywordsString)
     <div class="clearfix">
         <div class="input-field col s4">
             @Html.TextBoxFor(_ => _.Request.Name)
@@ -63,8 +70,14 @@
         </div>
     </div>
     <div class="col s12">
+        <div class="custom-form-label">@Html.DisplayNameFor(_ => _.Request.IgnoreKeywordsString)</div>
+        <div id="ignoreKeywords-chips" class="chips input-field">
+            <input class="input">
+        </div>
+    </div>
+    <div class="col s12">
         <div class="custom-form-label">@Html.DisplayNameFor(_ => _.Request.AllergyKeywordsString)</div>
-        <div id="allergykeywords-chips" class="chips input-field">
+        <div id="allergyKeywords-chips" class="chips input-field">
             <input class="input">
         </div>
     </div>

--- a/Application.Tests/IngredientApplicationServiceTests.cs
+++ b/Application.Tests/IngredientApplicationServiceTests.cs
@@ -79,7 +79,7 @@ namespace Application.Tests
             {
                 Id = 100,
                 Name = "Ingredient Update",
-                KeywordsString = "KeyWord1;KeyWord2",
+                KeywordsString = "Keyword1;Keyword2",
                 AllergyKeywordsString = "Allergy1;Allergy2"
             };
 
@@ -98,7 +98,7 @@ namespace Application.Tests
                 var ingredient = context.Ingredients.Find(100);
                 Assert.AreEqual(request.Name, ingredient.Name);
                 Assert.AreEqual(request.KeywordsString, ingredient.KeywordsString);
-                CollectionAssert.AreEqual(new string[] { "KeyWord1", "KeyWord2" }, ingredient.KeyWords);
+                CollectionAssert.AreEqual(new string[] { "Keyword1", "Keyword2" }, ingredient.Keywords);
                 Assert.AreEqual(request.AllergyKeywordsString, ingredient.AllergyKeywordsString);
                 CollectionAssert.AreEqual(new string[] { "Allergy1", "Allergy2" }, ingredient.AllergyKeywords);
             }

--- a/Application.Tests/IngredientApplicationServiceTests.cs
+++ b/Application.Tests/IngredientApplicationServiceTests.cs
@@ -79,8 +79,8 @@ namespace Application.Tests
             {
                 Id = 100,
                 Name = "Ingredient Update",
-                KeywordsString = "Keyword1;Keyword2",
-                AllergyKeywordsString = "Allergy1;Allergy2"
+                KeywordsString = "keyword1;keyword2",
+                AllergyKeywordsString = "allergy1;allergy2"
             };
 
             using (var context = new ApplicationContext(_options))
@@ -98,9 +98,9 @@ namespace Application.Tests
                 var ingredient = context.Ingredients.Find(100);
                 Assert.AreEqual(request.Name, ingredient.Name);
                 Assert.AreEqual(request.KeywordsString, ingredient.KeywordsString);
-                CollectionAssert.AreEqual(new string[] { "Keyword1", "Keyword2" }, ingredient.Keywords);
+                CollectionAssert.AreEqual(new string[] { "keyword1", "keyword2" }, ingredient.Keywords);
                 Assert.AreEqual(request.AllergyKeywordsString, ingredient.AllergyKeywordsString);
-                CollectionAssert.AreEqual(new string[] { "Allergy1", "Allergy2" }, ingredient.AllergyKeywords);
+                CollectionAssert.AreEqual(new string[] { "allergy1", "allergy2" }, ingredient.AllergyKeywords);
             }
         }
 

--- a/Application.Tests/ProductApplicationServiceTests.cs
+++ b/Application.Tests/ProductApplicationServiceTests.cs
@@ -248,7 +248,7 @@ namespace Application.Tests
                 Id = 200,
                 Name = "Ingredient 1",
                 VeganType = VeganType.Not,
-                AllergyKeywords = new[] { "notvegan" }
+                AllergyKeywordsString = "notvegan"
             };
 
             using (var context = new ApplicationContext(_options))
@@ -300,7 +300,7 @@ namespace Application.Tests
                 Id = 200,
                 Name = "Ingredient 1",
                 VeganType = VeganType.Unsure,
-                Keywords = new[] { "notvegan" }
+                KeywordsString = "notvegan"
             };
 
             using (var context = new ApplicationContext(_options))
@@ -353,7 +353,7 @@ namespace Application.Tests
                 Name = "Ingredient 1",
                 VeganType = VeganType.Unsure,
                 NeedsReview = true,
-                Keywords = new[] { "notvegan" }
+                KeywordsString = "notvegan"
             };
             using (var context = new ApplicationContext(_options))
             {
@@ -401,8 +401,8 @@ namespace Application.Tests
                     Id = 200,
                     Name = "Ingredient 1",
                     VeganType = VeganType.Not,
-                    Keywords = new[] { "notvegan" },
-                    AllergyKeywords = new[] { "notvegan" }
+                    KeywordsString = "notvegan",
+                    AllergyKeywordsString = "notvegan"
                 };
                 context.Ingredients.Add(ingredient);
 
@@ -492,7 +492,7 @@ namespace Application.Tests
                     Id = 200,
                     Name = "Ingredient 1",
                     VeganType = VeganType.Not,
-                    Keywords = new[] { "notvegan" }
+                    KeywordsString = "notvegan"
                 };
                 context.Ingredients.Add(ingredient);
 
@@ -531,7 +531,7 @@ namespace Application.Tests
                     Id = 200,
                     Name = "Ingredient 1",
                     VeganType = VeganType.Not,
-                    AllergyKeywords = new[] { "notvegan" }
+                    AllergyKeywordsString = "notvegan"
                 };
                 context.Ingredients.Add(ingredient);
 
@@ -571,8 +571,8 @@ namespace Application.Tests
                     Id = 200,
                     Name = "Ingredient 1",
                     VeganType = VeganType.Unsure,
-                    Keywords = new[] { "notvegan" },
-                    AllergyKeywords= new[] { "notvegan" }
+                    KeywordsString = "notvegan",
+                    AllergyKeywordsString = "notvegan"
                 };
                 context.Ingredients.Add(ingredient);
 
@@ -612,8 +612,8 @@ namespace Application.Tests
                     Id = 200,
                     Name = "Ingredient 1",
                     VeganType = VeganType.Not,
-                    Keywords = new[] { "notvegan" },
-                    AllergyKeywords = new[] { "notvegan" }
+                    KeywordsString = "notvegan",
+                    AllergyKeywordsString = "notvegan"
                 };
                 context.Ingredients.Add(ingredient);
 

--- a/Application.Tests/ProductApplicationServiceTests.cs
+++ b/Application.Tests/ProductApplicationServiceTests.cs
@@ -300,7 +300,7 @@ namespace Application.Tests
                 Id = 200,
                 Name = "Ingredient 1",
                 VeganType = VeganType.Unsure,
-                KeyWords = new[] { "notvegan" }
+                Keywords = new[] { "notvegan" }
             };
 
             using (var context = new ApplicationContext(_options))
@@ -353,7 +353,7 @@ namespace Application.Tests
                 Name = "Ingredient 1",
                 VeganType = VeganType.Unsure,
                 NeedsReview = true,
-                KeyWords = new[] { "notvegan" }
+                Keywords = new[] { "notvegan" }
             };
             using (var context = new ApplicationContext(_options))
             {
@@ -401,7 +401,7 @@ namespace Application.Tests
                     Id = 200,
                     Name = "Ingredient 1",
                     VeganType = VeganType.Not,
-                    KeyWords = new[] { "notvegan" },
+                    Keywords = new[] { "notvegan" },
                     AllergyKeywords = new[] { "notvegan" }
                 };
                 context.Ingredients.Add(ingredient);
@@ -492,7 +492,7 @@ namespace Application.Tests
                     Id = 200,
                     Name = "Ingredient 1",
                     VeganType = VeganType.Not,
-                    KeyWords = new[] { "notvegan" }
+                    Keywords = new[] { "notvegan" }
                 };
                 context.Ingredients.Add(ingredient);
 
@@ -571,7 +571,7 @@ namespace Application.Tests
                     Id = 200,
                     Name = "Ingredient 1",
                     VeganType = VeganType.Unsure,
-                    KeyWords = new[] { "notvegan" },
+                    Keywords = new[] { "notvegan" },
                     AllergyKeywords= new[] { "notvegan" }
                 };
                 context.Ingredients.Add(ingredient);
@@ -612,7 +612,7 @@ namespace Application.Tests
                     Id = 200,
                     Name = "Ingredient 1",
                     VeganType = VeganType.Not,
-                    KeyWords = new[] { "notvegan" },
+                    Keywords = new[] { "notvegan" },
                     AllergyKeywords = new[] { "notvegan" }
                 };
                 context.Ingredients.Add(ingredient);

--- a/Application/Services/ProductApplicationService.cs
+++ b/Application/Services/ProductApplicationService.cs
@@ -314,7 +314,7 @@ namespace Application.Services
 
         private bool DetectKeyword(Ingredient ingredient, Product product)
         {
-            foreach (var keyWord in ingredient.KeyWords)
+            foreach (var keyWord in ingredient.Keywords)
             {
                 var match = Regex.Match(" " + product.Ingredients + " ", @"[\s\W]" + keyWord + @"[\s\W]");
                 if (match.Success)

--- a/Application/Services/ProductApplicationService.cs
+++ b/Application/Services/ProductApplicationService.cs
@@ -314,9 +314,16 @@ namespace Application.Services
 
         private bool DetectKeyword(Ingredient ingredient, Product product)
         {
+            var ingredients = product.Ingredients;
+            foreach (var regex in ingredient.IgnoreKeywords)
+            {
+                ingredients = Regex.Replace(ingredients, regex, "");
+            }
+
             foreach (var keyWord in ingredient.Keywords)
             {
-                var match = Regex.Match(" " + product.Ingredients + " ", @"[\s\W]" + keyWord + @"[\s\W]");
+
+                var match = Regex.Match(" " + ingredients + " ", @"[\s\W]" + keyWord + @"[\s\W]");
                 if (match.Success)
                 {
                     return true;

--- a/Database/Migrations/20190302132722_ChangeKeyWordToKeyword.Designer.cs
+++ b/Database/Migrations/20190302132722_ChangeKeyWordToKeyword.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Model;
 
 namespace Database.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20190302132722_ChangeKeyWordToKeyword")]
+    partial class ChangeKeyWordToKeyword
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20190302132722_ChangeKeyWordToKeyword.cs
+++ b/Database/Migrations/20190302132722_ChangeKeyWordToKeyword.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Database.Migrations
+{
+    public partial class ChangeKeyWordToKeyword : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "AllergyKeyWords",
+                table: "Ingredients",
+                newName: "AllergyKeywords");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "AllergyKeywords",
+                table: "Ingredients",
+                newName: "AllergyKeyWords");
+        }
+    }
+}

--- a/Database/Migrations/20190302132917_AddIngredientIgnoreKeywords.Designer.cs
+++ b/Database/Migrations/20190302132917_AddIngredientIgnoreKeywords.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Model;
 
 namespace Database.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20190302132917_AddIngredientIgnoreKeywords")]
+    partial class AddIngredientIgnoreKeywords
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Database/Migrations/20190302132917_AddIngredientIgnoreKeywords.cs
+++ b/Database/Migrations/20190302132917_AddIngredientIgnoreKeywords.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Database.Migrations
+{
+    public partial class AddIngredientIgnoreKeywords : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "IgnoreKeywords",
+                table: "Ingredients",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IgnoreKeywords",
+                table: "Ingredients");
+        }
+    }
+}

--- a/Model/ApplicationContext.cs
+++ b/Model/ApplicationContext.cs
@@ -19,7 +19,6 @@ namespace Model
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.ApplyConfiguration(new IngredientConfiguration());
             modelBuilder.Entity<ProductIngredient>().HasKey(_ => new { _.ProductId, _.IngredientId });
             modelBuilder.Entity<ProductIngredient>()
                 .HasOne(_ => _.Product)

--- a/Model/ApplicationMapperConfiguration.cs
+++ b/Model/ApplicationMapperConfiguration.cs
@@ -11,8 +11,9 @@ namespace Model
         {
             //Ingredient
             CreateMap<IngredientUpdateRequest, Ingredient>(MemberList.Source)
-                .ForMember(_ => _.Keywords, opt => opt.Ignore())
-                .ForMember(_ => _.AllergyKeywords, opt => opt.Ignore());
+                .ForMember(_ => _.AllergyKeywordsString, opt => opt.MapFrom(i => i.AllergyKeywordsString.ToLower()))
+                .ForMember(_ => _.IgnoreKeywordsString, opt => opt.MapFrom(i => i.IgnoreKeywordsString.ToLower()))
+                .ForMember(_ => _.KeywordsString, opt => opt.MapFrom(i => i.KeywordsString.ToLower()));
             CreateMap<IngredientCreateRequest, Ingredient>(MemberList.Source);
 
             //Product

--- a/Model/ApplicationMapperConfiguration.cs
+++ b/Model/ApplicationMapperConfiguration.cs
@@ -11,7 +11,7 @@ namespace Model
         {
             //Ingredient
             CreateMap<IngredientUpdateRequest, Ingredient>(MemberList.Source)
-                .ForMember(_ => _.KeyWords, opt => opt.Ignore())
+                .ForMember(_ => _.Keywords, opt => opt.Ignore())
                 .ForMember(_ => _.AllergyKeywords, opt => opt.Ignore());
             CreateMap<IngredientCreateRequest, Ingredient>(MemberList.Source);
 

--- a/Model/Models/Ingredient.cs
+++ b/Model/Models/Ingredient.cs
@@ -14,19 +14,19 @@ namespace Model.Models
         [Column("Keywords")]
         public string KeywordsString { get; set; }
         [NotMapped]
-        public string[] KeyWords
+        public string[] Keywords
         {
             get { return !string.IsNullOrEmpty(KeywordsString) ? KeywordsString.Split(";") : new string[0]; }
-            set { KeywordsString = string.Join(";", value); }
+            set { KeywordsString = string.Join(";", value).ToLower(); }
         }
 
-        [Column("AllergyKeyWords")]
+        [Column("AllergyKeywords")]
         public string AllergyKeywordsString { get; set; }
         [NotMapped]
         public string[] AllergyKeywords
         {
             get { return !string.IsNullOrEmpty(AllergyKeywordsString) ? AllergyKeywordsString.Split(";") : new string[0]; }
-            set { AllergyKeywordsString = string.Join(";", value); }
+            set { AllergyKeywordsString = string.Join(";", value).ToLower(); }
         }
 
         public class IngredientConfiguration : IEntityTypeConfiguration<Ingredient>

--- a/Model/Models/Ingredient.cs
+++ b/Model/Models/Ingredient.cs
@@ -20,6 +20,15 @@ namespace Model.Models
             set { KeywordsString = string.Join(";", value).ToLower(); }
         }
 
+        [Column("IgnoreKeywords")]
+        public string IgnoreKeywordsString { get; set; }
+        [NotMapped]
+        public string[] IgnoreKeywords
+        {
+            get { return !string.IsNullOrEmpty(IgnoreKeywordsString) ? IgnoreKeywordsString.Split(";") : new string[0]; }
+            set { IgnoreKeywordsString = string.Join(";", value).ToLower(); }
+        }
+
         [Column("AllergyKeywords")]
         public string AllergyKeywordsString { get; set; }
         [NotMapped]

--- a/Model/Models/Ingredient.cs
+++ b/Model/Models/Ingredient.cs
@@ -17,7 +17,6 @@ namespace Model.Models
         public string[] Keywords
         {
             get { return !string.IsNullOrEmpty(KeywordsString) ? KeywordsString.Split(";") : new string[0]; }
-            set { KeywordsString = string.Join(";", value).ToLower(); }
         }
 
         [Column("IgnoreKeywords")]
@@ -26,7 +25,6 @@ namespace Model.Models
         public string[] IgnoreKeywords
         {
             get { return !string.IsNullOrEmpty(IgnoreKeywordsString) ? IgnoreKeywordsString.Split(";") : new string[0]; }
-            set { IgnoreKeywordsString = string.Join(";", value).ToLower(); }
         }
 
         [Column("AllergyKeywords")]
@@ -35,16 +33,6 @@ namespace Model.Models
         public string[] AllergyKeywords
         {
             get { return !string.IsNullOrEmpty(AllergyKeywordsString) ? AllergyKeywordsString.Split(";") : new string[0]; }
-            set { AllergyKeywordsString = string.Join(";", value).ToLower(); }
-        }
-
-        public class IngredientConfiguration : IEntityTypeConfiguration<Ingredient>
-        {
-            public void Configure(EntityTypeBuilder<Ingredient> builder)
-            {
-                builder.Property(_ => _.KeywordsString);
-                builder.Property(_ => _.AllergyKeywordsString);
-            }
         }
     }
 }

--- a/Model/Requests/IngredientRequests.cs
+++ b/Model/Requests/IngredientRequests.cs
@@ -26,6 +26,9 @@ namespace Model.Requests
         [Display(Name = "Ingredient_Keywords", ResourceType = typeof(DomainTerms))]
         public string KeywordsString { get; set; }
 
+        [Display(Name = "Ingredient_IgnoreKeywords", ResourceType = typeof(DomainTerms))]
+        public string IgnoreKeywordsString { get; set; }
+
         [Display(Name = "Ingredient_AllergyKeywords", ResourceType = typeof(DomainTerms))]
         public string AllergyKeywordsString { get; set; }
     }

--- a/Model/Resources/DomainTerms.Designer.cs
+++ b/Model/Resources/DomainTerms.Designer.cs
@@ -53,6 +53,12 @@ namespace Model.Resources {
             }
         }
         
+        public static string Ingredient_IgnoreKeywords {
+            get {
+                return ResourceManager.GetString("Ingredient_IgnoreKeywords", resourceCulture);
+            }
+        }
+        
         public static string Ingredient_Keywords {
             get {
                 return ResourceManager.GetString("Ingredient_Keywords", resourceCulture);

--- a/Model/Resources/DomainTerms.resx
+++ b/Model/Resources/DomainTerms.resx
@@ -15,8 +15,11 @@
     <data name="Ingredient_AllergyKeywords" xml:space="preserve">
         <value>Allergiën</value>
     </data>
+    <data name="Ingredient_IgnoreKeywords" xml:space="preserve">
+        <value>Ingrediënt negeren</value>
+    </data>
     <data name="Ingredient_Keywords" xml:space="preserve">
-        <value>Ingrediënten</value>
+        <value>Ingrediënt</value>
     </data>
     <data name="Ingredient_Name" xml:space="preserve">
         <value>Naam</value>


### PR DESCRIPTION
Ingredients should have keywords that will be ignored when matching a ingredient to a product.

For example a product with the ingredient 'natuurlijk bloedsinaasappel aroma' should not match on the word 'aroma'.