### PR TITLE
Fix searching in tables often yields no result

### DIFF
--- a/Api/Controllers/IngredientController.cs
+++ b/Api/Controllers/IngredientController.cs
@@ -6,6 +6,7 @@ using AutoMapper;
 using DataTables.AspNet.AspNetCore;
 using DataTables.AspNet.Core;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Model;
 
 namespace Api.Controllers
@@ -36,7 +37,7 @@ namespace Api.Controllers
 
             if (dataTablesRequest.Search.Value != null)
             {
-                ingredientsQuery = ingredientsQuery.Where(_ => _.Name.Contains(dataTablesRequest.Search.Value));
+                ingredientsQuery = ingredientsQuery.Where(_ => EF.Functions.Contains(_.Name, $"\"{dataTablesRequest.Search.Value}*\""));
             }
 
             var filteredCount = ingredientsQuery.Count();

--- a/Api/Controllers/ProductController.cs
+++ b/Api/Controllers/ProductController.cs
@@ -37,7 +37,7 @@ namespace Api.Controllers
 
             if (dataTablesRequest.Search.Value != null)
             {
-                productsQuery = productsQuery.Where(_ => _.Name.Contains(dataTablesRequest.Search.Value));
+                productsQuery = productsQuery.Where(_ => EF.Functions.Contains(_.Name, $"\"{dataTablesRequest.Search.Value}*\""));
             }
 
             var filteredCount = productsQuery.Count();
@@ -121,7 +121,7 @@ namespace Api.Controllers
 
             if (dataTablesRequest.Search.Value != null)
             {
-                productActivitiesQuery = productActivitiesQuery.Where(_ => _.Product.Name.Contains(dataTablesRequest.Search.Value));
+                productActivitiesQuery = productActivitiesQuery.Where(_ => EF.Functions.Contains(_.Product.Name, $"\"{dataTablesRequest.Search.Value}*\""));
             }
 
             var filteredCount = productActivitiesQuery.Count();

--- a/Api/Controllers/WorkloadController.cs
+++ b/Api/Controllers/WorkloadController.cs
@@ -36,7 +36,7 @@ namespace Api.Controllers
 
             if (dataTablesRequest.Search.Value != null)
             {
-                workLoadItemsQuery = workLoadItemsQuery.Where(_ => _.Product.Name.Contains(dataTablesRequest.Search.Value));
+                workLoadItemsQuery = workLoadItemsQuery.Where(_ => EF.Functions.Contains(_.Product.Name, $"\"{dataTablesRequest.Search.Value}*\""));
             }
 
             var filteredCount = workLoadItemsQuery.Count();

--- a/Database/CustomMigrations/CustomMigration_AddIngredientsNameFullTextSearchcs.cs
+++ b/Database/CustomMigrations/CustomMigration_AddIngredientsNameFullTextSearchcs.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Model;
+
+namespace Database.CustomMigrations
+{
+    [DbContext(typeof(ApplicationContext))]
+    [Migration("CustomMigration_AddIngredientsNameFullTextSearch")]
+    public class AddIngredientsNameFullTextSearch : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("CREATE FULLTEXT CATALOG IngredientsFullTextCatalog", true);
+            migrationBuilder.Sql("CREATE FULLTEXT INDEX ON [dbo].[Ingredients] ([Name]) KEY INDEX PK_Ingredients ON IngredientsFullTextCatalog WITH CHANGE_TRACKING AUTO;", true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP FULLTEXT INDEX ON [dbo].[Ingredients]", true);
+            migrationBuilder.Sql("DROP FULLTEXT CATALOG IngredientsFullTextCatalog", true);
+        }
+    }
+}

--- a/Database/CustomMigrations/CustomMigration_AddProductsNameFullTextSearchcs.cs
+++ b/Database/CustomMigrations/CustomMigration_AddProductsNameFullTextSearchcs.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Model;
+
+namespace Database.CustomMigrations
+{
+    [DbContext(typeof(ApplicationContext))]
+    [Migration("CustomMigration_AddProductsNameFullTextSearch")]
+    public class AddProductsNameFullTextSearch : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("CREATE FULLTEXT CATALOG ProductsFullTextCatalog", true);
+            migrationBuilder.Sql("CREATE FULLTEXT INDEX ON [dbo].[Products] ([Name]) KEY INDEX PK_Products ON ProductsFullTextCatalog WITH CHANGE_TRACKING AUTO;", true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP FULLTEXT INDEX ON [dbo].[Products]", true);
+            migrationBuilder.Sql("DROP FULLTEXT CATALOG ProductsFullTextCatalog", true);
+        }
+    }
+}

--- a/Database/Database.csproj
+++ b/Database/Database.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Migrations\" />
+    <Folder Include="CustomMigrations\" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">


### PR DESCRIPTION
Searching in the product, workload and ingredient table often yields no result. It only seems to be able to search on the first 3 to 4 letters.